### PR TITLE
support async content_manager

### DIFF
--- a/voila/handler.py
+++ b/voila/handler.py
@@ -13,7 +13,7 @@ import tornado.web
 
 from jupyter_server.base.handlers import JupyterHandler
 from jupyter_server.config_manager import recursive_update
-from jupyter_server.utils import url_path_join
+from jupyter_server.utils import url_path_join, ensure_async
 import nbformat
 
 from nbconvert.preprocessors import ClearOutputPreprocessor

--- a/voila/handler.py
+++ b/voila/handler.py
@@ -162,7 +162,7 @@ class VoilaHandler(JupyterHandler):
             yield res
 
     async def load_notebook(self, path):
-        model = self.contents_manager.get(path=path)
+        model = await ensure_async(self.contents_manager.get(path=path))
         if 'content' not in model:
             raise tornado.web.HTTPError(404, 'file not found')
         __, extension = os.path.splitext(model.get('path', ''))


### PR DESCRIPTION
support async content_manager such as AsyncLargeFileManager to prevent jupyter stucking on listing folders:
https://jupyter-server.readthedocs.io/en/latest/developers/contents.html#asynchronous-support